### PR TITLE
[WIP] attempt to make progress on teats + others for linear score to measurement

### DIFF
--- a/R/medial_curve.R
+++ b/R/medial_curve.R
@@ -104,21 +104,34 @@ body_polygon_df <- function(udder_floor_height, closeness_of_halves, depth_of_me
   )
 }
 
-
 # --- Scoring functions ---
+
+score_to_medial_inches <- function(score, goat_size = "standard") {
+  if (goat_size == "standard") {
+    scales::rescale(score, to = c(-1, 3), from = c(5, 45))
+  } else if (goat_size == "miniature") {
+    scales::rescale(score, to = c(-0.5, 1.5), from = c(5, 45))
+  } else {
+    stop("goat_size must be 'standard' or 'miniature'")
+  }
+}
+
+medial_inches_to_depth <- function(medial_inches, closeness_of_halves = 1) {
+  medial_inches / (closeness_of_halves + 1)^2
+}
 
 get_medial_score <- function(closeness_of_halves = 1, depth_of_medial = 0.15) {
   check_num(closeness_of_halves)
   check_num(depth_of_medial)
-
+  
   cleft_depth <- depth_of_medial * (closeness_of_halves + 1)^2
-
+  
   if (cleft_depth <= 0) {
     score <- max(1, min(5, 5 + cleft_depth * 5))
   } else {
     score <- 15 + cleft_depth * 10
   }
-
+  
   return(max(1, min(50, round(score))))
 }
 
@@ -139,27 +152,40 @@ get_udder_depth_score <- function(udder_floor_height = 13, hock_height = 18) {
   return(max(1, min(50, round(score))))
 }
 
-
 medial_visualization <- function(udder_floor_height = 13, closeness_of_halves = 1,
                                  depth_of_medial = 0.15, leg_width = 4.6,
-                                 hock_height = 18) {
+                                 hock_height = 18,
+                                 medial_score = NULL,
+                                 goat_size = "standard") {
   check_num(udder_floor_height)
   check_num(closeness_of_halves)
   check_num(depth_of_medial)
   check_num(leg_width)
   check_num(hock_height)
-
+  
+  if (!is.null(medial_score)) {
+    medial_inches <- score_to_medial_inches(
+      score = medial_score,
+      goat_size = goat_size
+    )
+    
+    depth_of_medial <- medial_inches_to_depth(
+      medial_inches = medial_inches,
+      closeness_of_halves = closeness_of_halves
+    )
+  }
+  
   df <- medial_df(udder_floor_height, closeness_of_halves,
                   depth_of_medial, leg_width)
-
+  
   ggplot(df) +
     aes(x = x, y = y) +
     geom_point() +
     geom_hline(yintercept = -hock_height, linetype = "dashed", color = "blue")
-
+  
   print("Medial Score:")
   print(get_medial_score(closeness_of_halves, depth_of_medial))
-
+  
   print("Udder Depth Score:")
   print(get_udder_depth_score(udder_floor_height, hock_height))
 }

--- a/R/teats_curve.R
+++ b/R/teats_curve.R
@@ -18,46 +18,60 @@
 
 library(tidyverse)
 
+score_to_teat_length <- function(score, goat_size = "standard") {
+  if (goat_size == "standard") {
+    scales::rescale(score, to = c(0.5, 5.0), from = c(5, 50))
+  } else if (goat_size == "miniature") {
+    scales::rescale(score, to = c(0.25, 2.5), from = c(5, 50))
+  } else {
+    stop("goat_size must be 'standard' or 'miniature'")
+  }
+}
+
+score_to_teat_diameter <- function(score, goat_size = "standard") {
+  if (goat_size == "standard") {
+    scales::rescale(score, to = c(0.5, 2.5), from = c(5, 45))
+  } else if (goat_size == "miniature") {
+    scales::rescale(score, to = c(0.25, 1.25), from = c(5, 45))
+  } else {
+    stop("goat_size must be 'standard' or 'miniature'")
+  }
+}
+
 teat_model <- function(teat_placement, teat_roundness, udder_floor_height,
                        teat_length, teat_diameter, leg_width,
-                       teat_length_score = NULL, n_points = 200) {
-
+                       teat_length_score = NULL,
+                       goat_size = "standard",
+                       n_points = 200) {
+  
   if (!is.null(teat_length_score)) {
-    if      (teat_length_score == 50) teat_length <- 5.0
-    else if (teat_length_score == 45) teat_length <- 4.5
-    else if (teat_length_score == 40) teat_length <- 4.0
-    else if (teat_length_score == 35) teat_length <- 3.5
-    else if (teat_length_score == 30) teat_length <- 3.0
-    else if (teat_length_score == 25) teat_length <- 2.5
-    else if (teat_length_score == 20) teat_length <- 2.0
-    else if (teat_length_score == 15) teat_length <- 1.5
-    else if (teat_length_score == 10) teat_length <- 1.0
-    else if (teat_length_score == 5)  teat_length <- 0.5
+    teat_length <- score_to_teat_length(
+      score = teat_length_score,
+      goat_size = goat_size
+    )
   }
-
+  
   x_left  <- seq(-leg_width, 0, length.out = n_points)
   x_right <- seq(0, leg_width, length.out = n_points)
-
+  
   y_left  <- teat_diameter * (x_left  + teat_placement) *
-             (x_left  + (teat_roundness + teat_placement)) -
-             (udder_floor_height + teat_length)
-
+    (x_left  + (teat_roundness + teat_placement)) -
+    (udder_floor_height + teat_length)
+  
   y_right <- teat_diameter * (x_right - teat_placement) *
-             (x_right - (teat_roundness + teat_placement)) -
-             (udder_floor_height + teat_length)
-
+    (x_right - (teat_roundness + teat_placement)) -
+    (udder_floor_height + teat_length)
+  
   df <- rbind(
     data.frame(x = x_left,  y = y_left),
     data.frame(x = x_right, y = y_right)
   )
-
+  
   ggplot(df, aes(x = x, y = y)) +
     geom_line() +
     coord_fixed(xlim = c(-20, 20), ylim = c(-30, 10)) +
     theme_minimal()
 }
-
-
 # Closed polygon for both teats. The top boundary of each teat polygon follows
 # the medial curve (udder floor) so the teats connect seamlessly to the udder body.
 # The bottom boundary is the teat parabola.

--- a/R/udder_curve.R
+++ b/R/udder_curve.R
@@ -16,6 +16,18 @@ check_num <- function(x) {
   if (!is.numeric(x)) print("Argument is not numeric")
 }
 
+# scoring functions 
+
+score_to_arch_roundness <- function(score) {
+  scales::rescale(score, to = c(18, 4), from = c(5, 50))
+}
+
+score_to_arch_shape <- function(score, leg_width) {
+  scales::rescale(score, to = c(leg_width + 0.25, leg_width + 4), from = c(5, 50))
+}
+
+# arch generation
+
 generate_arch <- function(arch_roundness, arch_height, arch_shape,
                           leg_width, n_points = 300) {
   check_num(arch_roundness)


### PR DESCRIPTION
Made progress towards the linear score translation to match the teat length and teat diameter via the linear SOP.

I tried to ensure that `score_to_teat_length()` converts a linear teat length score into inches. For standard goats, scores from 5 to 50 are mapped to 0.5–5.0 inches. For miniature goats, the same score range is mapped to 0.25–2.5 inches.

For the `score_to_teat_diameter()`, it will convert the linear teat diameter score into inches. For standard goats, scores from 5 to 45 are mapped to 0.5–2.5 inches. For miniature goats, the same score range is mapped to 0.25–1.25 inches. I tried to keep it in similar format to each other to make it easier, my main goal of this was to get rid of the if else(s).

